### PR TITLE
Auto-create databases directory during SQLite initialisation

### DIFF
--- a/functions/sql_funcs.py
+++ b/functions/sql_funcs.py
@@ -1,6 +1,5 @@
 # Database
 import datetime
-import os.path
 import sqlite3
 from pathlib import Path
 
@@ -11,6 +10,7 @@ DATABASE_PATH = Path(__file__).resolve().parents[1] / "databases" / "score_datab
 
 def _connect():
     # Centralized sqlite connection settings used by all DB operations.
+    DATABASE_PATH.parent.mkdir(parents=True, exist_ok=True)
     return sqlite3.connect(
         DATABASE_PATH,
         detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
@@ -184,5 +184,5 @@ def get_highscores(trials, time_per_guess):
         ).fetchall()
 
 
-if not os.path.isfile(DATABASE_PATH):
+if not DATABASE_PATH.exists():
     create_database()


### PR DESCRIPTION
## Summary
This PR fixes first-run startup failures when `databases/` is not present in the repository.

## Changes
- Updated `functions/sql_funcs.py`:
  - `_connect()` now creates `DATABASE_PATH.parent` (`databases/`) with:
    - `mkdir(parents=True, exist_ok=True)`
  - Replaced `os.path.isfile(DATABASE_PATH)` with `DATABASE_PATH.exists()` for initial DB creation check.
- Removed unnecessary `os.path` dependency from the module.

## Why
The app currently fails on import/initialisation if the `databases/` folder has been removed/ignored.  
This change makes DB setup self-healing so clean clones work without tracking local DB artefacts in git.

## Validation
- `python -m py_compile functions/sql_funcs.py`

## Result
Users can keep `databases/` ignored while still getting automatic DB creation on first launch.
